### PR TITLE
Add CV Partner Proof of Concept integration

### DIFF
--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -6,11 +6,15 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    environment: test
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
 
       - name: Install and Build
+        env:
+          CV_PARTNER_AUTHORIZATION: ${{ secrets.CV_PARTNER_AUTHORIZATION }}
+          CV_PARTNER_URL: ${{ secrets.CV_PARTNER_URL }}
         run: |
           yarn
           yarn build:static

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 ## Getting Started
 
-First, run the development server:
+Doppler:
+There are some secrets that you need in order to run the site, these can be found in doppler. If you don't have access to doppler, simply request access from hakon@savvy.no
+
+The project in doppler is called savvy-no and the dev enrivonment should be used when working locally.
+
+Running the development server:
+Then, run the development server with the doppler dev environment:
 
 ```bash
-yarn dev
+doppler run yarn dev
 ```

--- a/lib/content.interface.ts
+++ b/lib/content.interface.ts
@@ -27,7 +27,6 @@ export interface Home {
   heading: string
   ingress: string
   clients: Client[]
-  competence: string[]
 }
 
 export interface Clients {

--- a/lib/content.json
+++ b/lib/content.json
@@ -26,23 +26,7 @@
                     "backgroundPath": "/images/client-background-4.svg",
                     "name": "Adventure Tech"
                 }
-            ],
-            "competence": [
-                "Software development",
-                "Architecture",
-                "Agile",
-                "Mobile",
-                "Web",
-                "Frontend",
-                "Backend",
-                "Full stack",
-                "Tech Lead",
-                "Java",
-                ".NET",
-                "Javascript",
-                "React",
-                "Angular"
-            ]
+            ]        
         },
         "clients": {
             "metaTitle": "Savvy | Kunder",

--- a/lib/cvpartner.interface.ts
+++ b/lib/cvpartner.interface.ts
@@ -1,0 +1,257 @@
+export interface ICvPartnerClient {
+    getCv(userId: string, cvId: string): Promise<CvPartnerCv | null>
+    getUsers(): Promise<CvPartnerUser[]>
+}
+
+export interface CvPartnerUser {
+    id: string,
+    office_name: string
+    office_id: string
+    email: string
+    default_cv_id: string
+    telephone: string
+}
+
+export interface CvRole {
+    _id: string;
+    created_at: Date;
+    disabled: boolean;
+    diverged_from_master: boolean;
+    name: TranslatedString;
+    order: number;
+    starred: boolean;
+    years_of_experience: number;
+    years_of_experience_offset: number;
+}
+
+export interface Education {
+    _id: string;
+    created_at: Date;
+    degree: TranslatedString;
+    description: TranslatedString;
+    disabled: boolean;
+    diverged_from_master: boolean;
+    month_from: string;
+    month_to: string;
+    order: number;
+    owner_updated_at: Date;
+    recently_added: boolean;
+    school: TranslatedString;
+    starred: boolean;
+    updated_at: Date;
+    version: number;
+    year_from: string;
+    year_to: string;
+}
+
+export interface KeyQualification {
+    _id: string;
+    created_at: Date;
+    disabled: boolean;
+    diverged_from_master: boolean;
+    label: TranslatedString;
+    long_description: TranslatedString;
+    order: number;
+    owner_updated_at: Date;
+    recently_added: boolean;
+    starred: boolean;
+    updated_at: Date;
+    version: number;
+}
+
+export interface Language {
+    _id: string;
+    created_at: Date;
+    disabled: boolean;
+    diverged_from_master: boolean;
+    level: TranslatedString;
+    name: TranslatedString;
+    order: number;
+    owner_updated_at: Date;
+    recently_added: boolean;
+    starred: boolean;
+    updated_at: Date;
+    version: number;
+}
+
+export interface Role {
+    _id: string;
+    created_at: Date;
+    cv_role_id: string;
+    disabled: boolean;
+    diverged_from_master: boolean;
+    long_description: TranslatedString;
+    name: TranslatedString;
+    order: number;
+    recently_added: boolean;
+    starred: boolean;
+    updated_at: Date;
+    version: number;
+}
+
+export interface ProjectExperienceSkill {
+    _id: string;
+    base_duration_in_years: number;
+    offset_duration_in_years: number;
+    order: number;
+    proficiency: number;
+    tags?: TranslatedString;
+    total_duration_in_years: number;
+    version: number;
+}
+
+export interface ProjectExperience2 {
+    _id: string;
+    created_at: Date;
+    customer: TranslatedString;
+    customer_selected: string;
+    description: TranslatedString;
+    disabled: boolean;
+    diverged_from_master: boolean;
+    extent_hours: string;
+    industry: TranslatedString;
+    long_description: TranslatedString;
+    month_from: string;
+    month_to: string;
+    order: number;
+    owner_updated_at: Date;
+    percent_allocated: string;
+    project_extent_amt: string;
+    project_extent_currency: string;
+    project_extent_hours: string;
+    project_type: TranslatedString;
+    recently_added: boolean;
+    roles: Role[];
+    starred: boolean;
+    total_extent_amt: string;
+    total_extent_currency: string;
+    total_extent_hours: string;
+    updated_at: Date;
+    version: number;
+    year_from: string;
+    year_to: string;
+    project_experience_skills: ProjectExperienceSkill[];
+}
+
+export interface TechnologySkill {
+    _id: string;
+    base_duration_in_years: number;
+    offset_duration_in_years: number;
+    order: number;
+    proficiency: number;
+    tags?: TranslatedString;
+    total_duration_in_years: number;
+    version: number;
+}
+
+export interface Technology {
+    _id: string;
+    created_at: Date;
+    disabled: boolean;
+    diverged_from_master: boolean;
+    owner_updated_at: Date;
+    recently_added: boolean;
+    starred: boolean;
+    technology_skills: TechnologySkill[];
+    uncategorized: boolean;
+    updated_at: Date;
+    version: number;
+}
+
+export interface TranslatedString {
+    no?: string,
+    en?: string
+}
+
+
+export interface WorkExperience {
+    _id: string;
+    created_at: Date;
+    description: TranslatedString;
+    disabled: boolean;
+    diverged_from_master: boolean;
+    employer: TranslatedString;
+    long_description: TranslatedString;
+    month_from: string;
+    month_to: string;
+    order: number;
+    owner_updated_at: Date;
+    recently_added: boolean;
+    starred: boolean;
+    updated_at: Date;
+    version: number;
+    year_from: string;
+    year_to: string;
+}
+
+export interface CustomTagCategory {
+    _id: string;
+    id: string;
+    values: TranslatedString;
+    external_unique_id: string;
+    can_be_used_for_cvs: boolean;
+    can_be_used_for_references: boolean;
+    can_be_used_for_customers: boolean;
+    allow_filtering: boolean;
+}
+
+export interface CustomTag {
+    _id: string;
+    id: string;
+    values: TranslatedString;
+    external_unique_id: string;
+    custom_tag_category_id: string;
+    category_ids: string[];
+    custom_tag_category: CustomTagCategory;
+}
+
+export interface Url {
+    url: string;
+}
+
+export interface Image {
+    url: string;
+    thumb: Url;
+    fit_thumb: Url;
+    large: Url;
+    small_thumb: Url;
+}
+
+export interface CvPartnerCv {
+    _id: string;
+    born_day: number;
+    born_month: number;
+    born_year: number;
+    bruker_id: string;
+    created_at: Date;
+    custom_tag_ids: string[];
+    cv_roles: CvRole[];
+    default: boolean;
+    educations: Education[];
+    key_qualifications: KeyQualification[];
+    languages: Language[];
+    nationality: TranslatedString;
+    navn: string;
+    place_of_residence: TranslatedString;
+    project_experiences: ProjectExperience2[];
+    technologies: Technology[];
+    telefon: string;
+    title: TranslatedString;
+    updated_at: Date;
+    version: number;
+    work_experiences: WorkExperience[];
+    name: string;
+    user_id: string;
+    external_unique_id: string;
+    email: string;
+    country_code: string;
+    language_code: string;
+    language_codes: string[];
+    custom_tags: CustomTag[];
+    updated_ago: string;
+    template_document_type: string;
+    default_word_template_id: string;
+    image: Image;
+    can_write: boolean;
+}
+

--- a/lib/cvpartner.ts
+++ b/lib/cvpartner.ts
@@ -1,0 +1,42 @@
+import { CvPartnerCv, CvPartnerUser, ICvPartnerClient } from "./cvpartner.interface";
+
+export class CvPartnerClient implements ICvPartnerClient {
+    private baseUrl: string
+    private authorization: string
+
+    public constructor() {
+        if (process.env.CV_PARTNER_URL) {
+            this.baseUrl = process.env.CV_PARTNER_URL;
+        } else {
+            throw new Error("CV_PARTNER_URL must be defined")
+        }
+
+        if (process.env.CV_PARTNER_AUTHORIZATION) {
+            this.authorization = process.env.CV_PARTNER_AUTHORIZATION
+        } else {
+            throw new Error("CV_PARTNER_AUTHORIZATION must be defined")
+        }
+    }
+    async getCv(userId: string, cvId: string): Promise<CvPartnerCv> {
+        const url = new URL(`/api/v3/cvs/${userId}/${cvId}`, this.baseUrl)
+        const response = await fetch(url.href, {
+            headers: {
+                "Authorization": this.authorization
+            }
+        })
+        const body = await response.json()
+
+        return body as CvPartnerCv
+    }
+    async getUsers(): Promise<CvPartnerUser[]> {
+        const url = new URL("/api/v1/users", this.baseUrl)
+        const response = await fetch(url.href, {
+            headers: {
+                "Authorization": this.authorization
+            }
+        })
+        const body = await response.json()
+
+        return body as CvPartnerUser[]
+    }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,8 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  env : {
+  }
 }
 
 module.exports = nextConfig

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -155,7 +155,7 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
 
   const users = await client.getUsers()
 
-  var skills = new Array<string>()
+  let skills = new Array<string>()
 
   for (const user of users) {
     const cv = await client.getCv(user.id, user.default_cv_id)


### PR DESCRIPTION
Adds a proof of concept CVPartner integration.

For now all we use the integration for is to populate the marquee of skills. It randomly selects 30 skills from all of the CVs that are available.

In order to communicate with the CVPartner API we need to use an API key, this has been added to our environment secrets.
In addition I've also added the CVPartner API URL as a secret as well in order to make it configurable. 

Unfortunately CVPartner does not have an API schema definition that we can access, so I've not been able to generate models or clients to work with the API. I've generated the models from some JSON responses that I've received from the API and then trimmed them down and cleaned them up a bit. 