### PR TITLE
Add feature flag for cv partner integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ Then, run the development server with the doppler dev environment:
 ```bash
 doppler run yarn dev
 ```
+
+### Feature flags:
+
+- FEATURE_CV_PARTNER_INTEGRATION_ENABLED - Enables the integration with CVPartner. Usually disabled when working locally as it makes dynamic page loads rather slow.

--- a/lib/cvpartner.interface.ts
+++ b/lib/cvpartner.interface.ts
@@ -141,21 +141,11 @@ export interface TechnologySkill {
     proficiency: number;
     tags?: TranslatedString;
     total_duration_in_years: number;
-    version: number;
 }
 
 export interface Technology {
     _id: string;
-    created_at: Date;
-    disabled: boolean;
-    diverged_from_master: boolean;
-    owner_updated_at: Date;
-    recently_added: boolean;
-    starred: boolean;
     technology_skills: TechnologySkill[];
-    uncategorized: boolean;
-    updated_at: Date;
-    version: number;
 }
 
 export interface TranslatedString {
@@ -222,7 +212,6 @@ export interface CvPartnerCv {
     born_day: number;
     born_month: number;
     born_year: number;
-    bruker_id: string;
     created_at: Date;
     custom_tag_ids: string[];
     cv_roles: CvRole[];
@@ -238,20 +227,14 @@ export interface CvPartnerCv {
     telefon: string;
     title: TranslatedString;
     updated_at: Date;
-    version: number;
     work_experiences: WorkExperience[];
     name: string;
     user_id: string;
-    external_unique_id: string;
     email: string;
     country_code: string;
     language_code: string;
     language_codes: string[];
     custom_tags: CustomTag[];
-    updated_ago: string;
-    template_document_type: string;
-    default_word_template_id: string;
-    image: Image;
-    can_write: boolean;
+    image?: Image;
 }
 

--- a/lib/cvpartner.ts
+++ b/lib/cvpartner.ts
@@ -1,22 +1,30 @@
 import { CvPartnerCv, CvPartnerUser, ICvPartnerClient } from "./cvpartner.interface";
 
-export class CvPartnerClient implements ICvPartnerClient {
-    private baseUrl: string
-    private authorization: string
+export class CvPartnerClientFactory {
+    public static Create(): ICvPartnerClient {
+        if (process.env.FEATURE_CV_PARTNER_INTEGRATION_ENABLED === "true") {
 
-    public constructor() {
-        if (process.env.CV_PARTNER_URL) {
-            this.baseUrl = process.env.CV_PARTNER_URL;
-        } else {
-            throw new Error("CV_PARTNER_URL must be defined")
+            if (!process.env.CV_PARTNER_URL) {
+                throw new Error("CV_PARTNER_URL must be defined")
+            }
+
+            if (!process.env.CV_PARTNER_AUTHORIZATION) {
+                throw new Error("CV_PARTNER_AUTHORIZATION must be defined")
+            }
+
+            return new CvPartnerClient(
+                process.env.CV_PARTNER_URL,
+                process.env.CV_PARTNER_AUTHORIZATION
+            )
         }
 
-        if (process.env.CV_PARTNER_AUTHORIZATION) {
-            this.authorization = process.env.CV_PARTNER_AUTHORIZATION
-        } else {
-            throw new Error("CV_PARTNER_AUTHORIZATION must be defined")
-        }
+        return new MockedCvPartnerClient()
     }
+}
+
+class CvPartnerClient implements ICvPartnerClient {
+    public constructor(private baseUrl: string, private authorization: string) { }
+
     async getCv(userId: string, cvId: string): Promise<CvPartnerCv> {
         const url = new URL(`/api/v3/cvs/${userId}/${cvId}`, this.baseUrl)
         const response = await fetch(url.href, {
@@ -39,4 +47,112 @@ export class CvPartnerClient implements ICvPartnerClient {
 
         return body as CvPartnerUser[]
     }
+}
+
+class MockedCvPartnerClient implements ICvPartnerClient {
+
+    async getCv(userId: string, cvId: string): Promise<CvPartnerCv | null> {
+        return {
+            _id: cvId,
+            born_day: 20,
+            born_month: 10,
+            born_year: 1990,
+            created_at: new Date(),
+            custom_tag_ids: [],
+            cv_roles: [],
+            default: true,
+            educations: [],
+            key_qualifications: [],
+            languages: [],
+            nationality: { no: "Norsk" },
+            navn: "Test Testersen",
+            place_of_residence: { no: "Bergen" },
+            project_experiences: [],
+            technologies: [{
+                _id: "123",
+                technology_skills: [
+                    {
+                        _id: "321",
+                        base_duration_in_years: 1,
+                        offset_duration_in_years: 1,
+                        order: 0,
+                        proficiency: 1,
+                        total_duration_in_years: 2,
+                        tags: {
+                            no: "Java"
+                        }
+                    },
+                    {
+                        _id: "321",
+                        base_duration_in_years: 1,
+                        offset_duration_in_years: 1,
+                        order: 0,
+                        proficiency: 1,
+                        total_duration_in_years: 2,
+                        tags: {
+                            no: "Javascript"
+                        }
+                    },
+                    {
+                        _id: "321",
+                        base_duration_in_years: 1,
+                        offset_duration_in_years: 1,
+                        order: 0,
+                        proficiency: 1,
+                        total_duration_in_years: 2,
+                        tags: {
+                            no: "Typescript"
+                        }
+                    },
+                    {
+                        _id: "321",
+                        base_duration_in_years: 1,
+                        offset_duration_in_years: 1,
+                        order: 0,
+                        proficiency: 1,
+                        total_duration_in_years: 2,
+                        tags: {
+                            no: "NodeJS"
+                        }
+                    },
+                    {
+                        _id: "321",
+                        base_duration_in_years: 1,
+                        offset_duration_in_years: 1,
+                        order: 0,
+                        proficiency: 1,
+                        total_duration_in_years: 2,
+                        tags: {
+                            no: ".NET"
+                        }
+                    },
+                ]
+            }],
+            telefon: "45674567",
+            title: { no: "Test Testersen" },
+            updated_at: new Date(),
+            work_experiences: [],
+            name: "Test Testersen",
+            user_id: userId,
+            email: "test.testersen@savvy.no",
+            country_code: "no",
+            language_code: "no-NB",
+            language_codes: ["no-NB"],
+            custom_tags: []
+        }
+    }
+
+    async getUsers(): Promise<CvPartnerUser[]> {
+        return [
+            {
+                id: "123123",
+                office_name: "Savvy",
+                office_id: "321321",
+                email: "hakon@savvy.no",
+                default_cv_id: "789789",
+                telephone: "45674567"
+            }
+        ]
+    }
+
 }

--- a/next.config.js
+++ b/next.config.js
@@ -9,8 +9,6 @@ const nextConfig = {
   },
   images: {
     unoptimized: true,
-  },
-  env : {
   }
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link'
 import { Button } from 'components/Button/Button'
 import { HalfImage } from 'components/HalfImage/HalfImage'
 import { HorizontalScrollContainer } from 'components/HorizontalScrollContainer/HorizontalScrollContainer'
-import { CvPartnerClient } from '@/lib/cvpartner'
+import { CvPartnerClientFactory } from '@/lib/cvpartner'
 import { GetStaticProps } from 'next/types'
 
 type Props = { skills: string[] }
@@ -151,7 +151,7 @@ export default function Index({ skills }: Props) {
 }
 
 export const getStaticProps: GetStaticProps<Props> = async () => {
-  const client = new CvPartnerClient()
+  const client = CvPartnerClientFactory.Create()
 
   const users = await client.getUsers()
 
@@ -159,6 +159,10 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
 
   for (const user of users) {
     const cv = await client.getCv(user.id, user.default_cv_id)
+
+    if (!cv) {
+      continue
+    }
 
     const userSkills = cv.technologies
       .flatMap((technology) => technology.technology_skills)


### PR DESCRIPTION
Adds a feature flag that can enable or disable the integration with CVPartner. If the feature flag is disabled we fallback to a hardcoded list of skills. Disabling the integration is primarily intended to be used when developing locally, because the integration is a bit slow, which can be annoying.