### PR TITLE
Replace font based icons with SVGs

### DIFF
--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -1,6 +1,8 @@
 import clsx from 'clsx'
 import React from 'react'
 import styles from './Button.module.scss'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faLongArrowRight, faPlus } from '@fortawesome/pro-regular-svg-icons'
 
 interface Props extends React.PropsWithChildren {
   type?: 'button' | 'submit'
@@ -33,9 +35,9 @@ export const Button = ({
       <div className={styles['button__content']}>{children}</div>
       <div className={styles['button__icon']}>
         {icon === 'arrow' ? (
-          <i className="far fa-long-arrow-right fa-fw fa-md" />
+          <FontAwesomeIcon icon={faLongArrowRight} />
         ) : (
-          <i className="far fa-plus fa-fw fa-md" />
+          <FontAwesomeIcon icon={faPlus} />
         )}
       </div>
     </button>

--- a/components/Modals/BaseModal.tsx
+++ b/components/Modals/BaseModal.tsx
@@ -1,6 +1,8 @@
 import { Dialog } from '@headlessui/react'
 import clsx from 'clsx'
 import styles from './Modals.module.scss'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faTimes } from '@fortawesome/pro-regular-svg-icons'
 
 interface Props extends React.PropsWithChildren {
   isOpen: boolean
@@ -17,7 +19,7 @@ export const BaseModal = ({ isOpen, onClose, color = 'primary-dark', children }:
             {children}
           </Dialog.Panel>
           <button type="button" className={styles['close-button']} onClick={onClose}>
-            <i className="far fa-times"></i>
+            <FontAwesomeIcon icon={faTimes} />
           </button>
         </div>
       </div>

--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -5,6 +5,9 @@ import styles from './Nav.module.scss'
 import { useState } from 'react'
 import { MobileMenuModal } from '../Modals/MobileMenuModal'
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faEquals } from '@fortawesome/pro-regular-svg-icons'
+
 export const Nav = () => {
   const [modalIsOpen, setModalIsOpen] = useState<boolean>(false)
 
@@ -58,7 +61,7 @@ export const Nav = () => {
                 aria-label="Open menu"
                 onClick={() => setModalIsOpen(true)}
               >
-                <i className="far fa-equals faw" />
+                <FontAwesomeIcon icon={faEquals} />
               </button>
             </div>
           </div>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "doppler:setup": "doppler setup --project 'savvy-no' --config 'dev'"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-pro": "^6.2.0",
+    "@fortawesome/fontawesome-svg-core": "^6.2.1",
+    "@fortawesome/pro-regular-svg-icons": "^6.2.1",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "@headlessui/react": "^1.7.4",
     "@types/node": "18.11.8",
     "@types/react": "18.0.24",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,11 +1,14 @@
 import { AppProps } from 'next/app'
-import '../node_modules/@fortawesome/fontawesome-pro/css/all.min.css'
 import '@/styles/globals.scss'
 import Layout from './layout'
 import Head from 'next/head'
 import content from '@/lib/content.json'
 import { Pages } from '@/lib/content.interface'
 import Script from 'next/script'
+
+import { config } from '@fortawesome/fontawesome-svg-core'
+import '@fortawesome/fontawesome-svg-core/styles.css'
+config.autoAddCss = false
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   const { agency } = content.pages as Pages

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,31 @@
   resolved "https://registry.yarnpkg.com/@corex/deepmerge/-/deepmerge-4.0.29.tgz#af9debf07d7f6b0d2a9d04a266abf2c1418ed2f6"
   integrity sha512-q/yVUnqckA8Do+EvAfpy7RLdumnBy9ZsducMUtZTvpdbJC7azEf1hGtnYYxm0QfphYxjwggv6XtH64prvS1W+A==
 
-"@fortawesome/fontawesome-pro@^6.2.0":
-  version "6.2.0"
-  resolved "https://npm.fontawesome.com/@fortawesome/fontawesome-pro/-/6.2.0/fontawesome-pro-6.2.0.tgz#cfb0f1c8f4b33c5bee85fc337c29f77486a82611"
-  integrity sha512-T1JhszQ75ofAaa42XWBte5KsiBb7YM6CKMZTiR3zL0CHZGBabPg8J5FgMoJYlaxgrfLf+jOebDnoB0h43ljAsA==
+"@fortawesome/fontawesome-common-types@6.2.1":
+  version "6.2.1"
+  resolved "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/6.2.1/fontawesome-common-types-6.2.1.tgz#411e02a820744d3f7e0d8d9df9d82b471beaa073"
+  integrity sha512-Sz07mnQrTekFWLz5BMjOzHl/+NooTdW8F8kDQxjWwbpOJcnoSg4vUDng8d/WR1wOxM0O+CY9Zw0nR054riNYtQ==
+
+"@fortawesome/fontawesome-svg-core@^6.2.1":
+  version "6.2.1"
+  resolved "https://npm.fontawesome.com/@fortawesome/fontawesome-svg-core/-/6.2.1/fontawesome-svg-core-6.2.1.tgz#e87e905e444b5e7b715af09b64d27b53d4c8f9d9"
+  integrity sha512-HELwwbCz6C1XEcjzyT1Jugmz2NNklMrSPjZOWMlc+ZsHIVk+XOvOXLGGQtFBwSyqfJDNgRq4xBCwWOaZ/d9DEA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.2.1"
+
+"@fortawesome/pro-regular-svg-icons@^6.2.1":
+  version "6.2.1"
+  resolved "https://npm.fontawesome.com/@fortawesome/pro-regular-svg-icons/-/6.2.1/pro-regular-svg-icons-6.2.1.tgz#b2598ba93def3e1ca0d6c48dc6b08b6f97597738"
+  integrity sha512-U3JCqJjwkNSrxgDafsBBUQBbOlvTsa4Odtn7m01NDko45pZu2nh3eqCexovy4y6LzWXXP/Spq+AO29CBpCW8yA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.2.1"
+
+"@fortawesome/react-fontawesome@^0.2.0":
+  version "0.2.0"
+  resolved "https://npm.fontawesome.com/@fortawesome/react-fontawesome/-/0.2.0/react-fontawesome-0.2.0.tgz#d90dd8a9211830b4e3c08e94b63a0ba7291ddcf4"
+  integrity sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==
+  dependencies:
+    prop-types "^15.8.1"
 
 "@headlessui/react@^1.7.4":
   version "1.7.4"
@@ -235,7 +256,7 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-loose-envify@^1.1.0:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -291,6 +312,11 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
+
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
@@ -310,6 +336,15 @@ postcss@8.4.14:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+prop-types@^15.8.1:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 react-dom@18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
@@ -317,6 +352,11 @@ react-dom@18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
+
+react-is@^16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react@18.2.0:
   version "18.2.0"


### PR DESCRIPTION
Currently we load a font file that is approximately 400kb large just because we have something like 4 icons in use on the site. This PR replaces the icons with SVG based icons.